### PR TITLE
change context package from x/context to context

### DIFF
--- a/flow.go
+++ b/flow.go
@@ -1,9 +1,8 @@
 package ctxflow
 
 import (
+	"context"
 	"fmt"
-
-	"golang.org/x/net/context"
 )
 
 // FlowFunc is a function that receives context and returns error

--- a/flow_test.go
+++ b/flow_test.go
@@ -1,14 +1,12 @@
 package ctxflow
 
 import (
+	"context"
 	"errors"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
-
-	"runtime"
-
-	"golang.org/x/net/context"
 )
 
 var errSome = errors.New("someError")

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,5 +1,5 @@
 build:
-  box: golang:1.6
+  box: golang:1.7
   steps:
     - setup-go-workspace:
       package-dir: github.com/wacul/ctxflow


### PR DESCRIPTION
To use a new `context` package instead of `golang.org/x/net/context`.
Merging this PR, some services not vendoring this package will be not able to be built.